### PR TITLE
fixed comments starting with '#'

### DIFF
--- a/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.YAML-tmLanguage
+++ b/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.YAML-tmLanguage
@@ -57,7 +57,8 @@ repository:
   comments:
     patterns:
     - name: comment.line
-      match: ;.*$
+      begin: (;|(\#\s))
+      end: (\n|(\r\n))
     - name: comment.block
       begin: /\*
       end: \*/


### PR DESCRIPTION
This PR enables syntax highlighting for comment lines starting with '#' (without breaking preprocessor commands highlighting).