### PR TITLE
Classify PROC & ENDP statements

### DIFF
--- a/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.tmLanguage
+++ b/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.tmLanguage
@@ -297,6 +297,25 @@
 					<key>name</key>
 					<string>invalid.illegal.entity.name.function.asm.x86_64</string>
 				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.asm.x86_64</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.function.asm.x86_64</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>([[:alnum:]]+) (PROC|ENDP)</string>
+					<key>name</key>
+					<string>meta.function.asm.x86_64</string>
+				</dict>
 			</array>
 		</dict>
 		<key>mnemonics</key>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/63328889/235312446-c751c210-06a3-47c9-ad36-5e33ff32e79a.png)

After:
![image](https://user-images.githubusercontent.com/63328889/235312439-8db66a26-5b09-4da4-9c76-47a0231de452.png)

I also think the `.CODE` part could be classified as something, maybe comment.