### PR TITLE
Allow optional "ptr" suffix for type names

### DIFF
--- a/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.tmLanguage
+++ b/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.tmLanguage
@@ -1868,7 +1868,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(?i)\b(?:s?byte|(?:[doqtyz]|dq|s[dq]?)?word|(?:d|res)[bdoqtwyz]|ddq)\b</string>
+					<string>(?i)\b(?:s?byte|(?:[doqtyz]|dq|s[dq]?)?word|(?:d|res)[bdoqtwyz]|ddq)(?: ptr)?\b</string>
 					<key>name</key>
 					<string>storage.type.asm.x86_64</string>
 				</dict>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/63328889/235312660-32dc3407-76e5-4307-90f1-deef8fe5d874.png)
After:
![image](https://user-images.githubusercontent.com/63328889/235312649-195c0937-a617-46c3-a882-4cbc94391f9f.png)