### PR TITLE
Add %rotate, fix defines and macro match

### DIFF
--- a/x86_64 Assembly.tmbundle/Syntaxes/Nasm Assembly.sublime-syntax
+++ b/x86_64 Assembly.tmbundle/Syntaxes/Nasm Assembly.sublime-syntax
@@ -544,7 +544,7 @@ contexts:
         - include: strings
         - include: line-ending
         - include: preprocessor-macro-indirection
-    - match: '^\s*((%)(?:assign|i?deftok|strcat|strlen|substr|pathsearch|push|pop|repl|line|clear))\b'
+    - match: '^\s*((%)(?:assign|i?deftok|strcat|strlen|substr|pathsearch|push|pop|rotate|repl|line|clear))\b'
       captures:
         1: meta.preprocessor.asm.x86_64 keyword.control.preprocessor.asm.x86_64
         2: punctuation.definition.keyword.preprocessor.asm.x86_64

--- a/x86_64 Assembly.tmbundle/Syntaxes/Nasm Assembly.sublime-syntax
+++ b/x86_64 Assembly.tmbundle/Syntaxes/Nasm Assembly.sublime-syntax
@@ -544,7 +544,7 @@ contexts:
         - include: strings
         - include: line-ending
         - include: preprocessor-macro-indirection
-    - match: '^\s*((%)(?:assign|i?deftok|strcat|strlen|substr|pathsearch|push|pop|rotate|repl|line|clear))\b'
+    - match: '^\s*((%)(?:assign|i?deftok|strcat|strlen|substr|pathsearch|push|pop|repl|line|clear))\b'
       captures:
         1: meta.preprocessor.asm.x86_64 keyword.control.preprocessor.asm.x86_64
         2: punctuation.definition.keyword.preprocessor.asm.x86_64

--- a/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.YAML-tmLanguage
+++ b/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.YAML-tmLanguage
@@ -188,7 +188,7 @@ repository:
           '0': {name: punctuation.definition.string.end.c}
     
     - name: meta.preprocessor.c
-      begin: ^\s*[%#]\s*(i?x?define|defined|elif(def)?|else|if(macro|ctx|idni?|num|str)?|ifn?def|line|(end|i)?macro|pragma|undef|endif)\b
+      begin: ^\s*[%#]\s*(i?x?define|defined|elif(def)?|else|if(macro|ctx|idni?|num|str)?|ifn?def|line|(i|end)?macro|pragma|undef|endif)\b
       end: (?=(?://|/\*))|$
       captures:
         '1': {name: keyword.control.import.c}

--- a/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.YAML-tmLanguage
+++ b/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.YAML-tmLanguage
@@ -188,7 +188,7 @@ repository:
           '0': {name: punctuation.definition.string.end.c}
     
     - name: meta.preprocessor.c
-      begin: ^\s*[%#]\s*((xi?)?define|defined|elif(def)?|else|if(macro|ctx|idni?|num|str)?|ifn?def|line|(end)?macro|pragma|undef|endif)\b
+      begin: ^\s*[%#]\s*(i?x?define|defined|elif(def)?|else|if(macro|ctx|idni?|num|str)?|ifn?def|line|(end|i)?macro|pragma|undef|endif)\b
       end: (?=(?://|/\*))|$
       captures:
         '1': {name: keyword.control.import.c}
@@ -197,7 +197,7 @@ repository:
         name: punctuation.separator.continuation.c
 
     - name: meta.preprocessor.nasm
-      begin: ^\s*[#%]\s*(assign|strlen|substr|(end|exit)?rep|push|pop)\b
+      begin: ^\s*[#%]\s*(assign|strlen|substr|(end|exit)?rep|push|pop|rotate)\b
       end: $
       captures:
         '1': {name: keyword.control}

--- a/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.tmLanguage
+++ b/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.tmLanguage
@@ -1611,7 +1611,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>^\s*[%#]\s*(i?x?define|defined|elif(def)?|else|if(macro|ctx|idni?|num|str)?|ifn?def|line|(end|i)?macro|pragma|undef|endif)\b</string>
+					<string>^\s*[%#]\s*(i?x?define|defined|elif(def)?|else|if(macro|ctx|idni?|num|str)?|ifn?def|line|(i|end)?macro|pragma|undef|endif)\b</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>

--- a/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.tmLanguage
+++ b/x86_64 Assembly.tmbundle/Syntaxes/x86_64 Assembly.tmLanguage
@@ -1611,7 +1611,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>^\s*[%#]\s*((xi?)?define|defined|elif(def)?|else|if(macro|ctx|idni?|num|str)?|ifn?def|line|(end)?macro|pragma|undef|endif)\b</string>
+					<string>^\s*[%#]\s*(i?x?define|defined|elif(def)?|else|if(macro|ctx|idni?|num|str)?|ifn?def|line|(end|i)?macro|pragma|undef|endif)\b</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>
@@ -1636,7 +1636,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>^\s*[#%]\s*(assign|strlen|substr|(end|exit)?rep|push|pop)\b</string>
+					<string>^\s*[#%]\s*(assign|strlen|substr|(end|exit)?rep|push|pop|rotate)\b</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Fixes the following matches
  - `%rotate`
  - `%idefine`,`%xdefine`,`%ixdefine`,`%define`
  - `%imacro`
